### PR TITLE
fix downloads for MediaWiki 1.24 and later

### DIFF
--- a/src/main/php/download/Download.php
+++ b/src/main/php/download/Download.php
@@ -29,8 +29,17 @@ $mediaWikiBaseDir = dirname( __FILE__ ) . '/../../..';
 chdir($mediaWikiBaseDir);
 $preIP = \getcwd();
 require_once( "$preIP/includes/WebStart.php" );
+# MediaWiki class source file was renamed from Wiki.php to
+# MediaWiki.php starting with version 1.24.
+# See Change-Id: I53dfa5ae98c8f45b32f911419217692cfd760cd7
+$oldVersion = version_compare( $wgVersion, '1.24', '<' );
+if ( $oldVersion ) {
+	$mediaWikiClassFile = 'Wiki.php';
+} else {
+	$mediaWikiClassFile = 'MediaWiki.php';
+}
 # Initialize MediaWiki base class
-require_once( "$preIP/includes/Wiki.php" );
+require_once( "$preIP/includes/$mediaWikiClassFile" );
 $mediaWiki = new \MediaWiki();
 // Stream the requested file
 $requestHandler = new \PageAttachment\RequestHandler();


### PR DESCRIPTION
In MediaWiki 1.24, the name of the PHP source file that contains
the MediaWiki class definition was changed from Wiki.php to
MediaWiki.php.  See MediaWiki commit with Change-Id
I53dfa5ae98c8f45b32f911419217692cfd760cd7.

For that release and on, attachment downloads get broken because
the require_once directive that pulls in the definition for the
MediaWiki class fails.  You see error messages that look like:

```
[Wed Jul 29 14:41:13 2015] [error] [client 10.9.1.232] PHP Fatal error:  require_once(): Failed opening required '/var/www/html/mediawiki-1.25.1/includes/Wiki.php' (include_path='.:/usr/share/pear:/usr/share/php') in /var/www/html/mediawiki-1.25.1/extensions/PageAttachment/download/Download.php on line 33, referer: https://wiki.somehost.com/wiki/index.php/Page_With_Attachment
```

This commit addresses the problem by testing for MediaWiki version
and setting the name of the MediaWiki class file to the appropriate
value, thereby retaining prior compatibility.